### PR TITLE
Update event payload to send JSON object

### DIFF
--- a/collector/components/servicenowexporter/servicenow.go
+++ b/collector/components/servicenowexporter/servicenow.go
@@ -3,7 +3,6 @@ package servicenowexporter
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"strconv"
 	"strings"
 
@@ -362,7 +361,7 @@ func buildPath(name string, attributes pcommon.Map) string {
 	return buf.String()
 }
 
-func formatAdditionalInfo(attrs map[string]string, resourceAttrs map[string]string) (string, error) {
+func formatAdditionalInfo(attrs map[string]string, resourceAttrs map[string]string) (map[string]string, error) {
 	// merge attrs + resource attrs
 	newAttrs := make(map[string]string)
 	for k, v := range resourceAttrs {
@@ -383,11 +382,7 @@ func formatAdditionalInfo(attrs map[string]string, resourceAttrs map[string]stri
 		newAttrs[k] = v
 	}
 
-	bytes, err := json.Marshal(newAttrs)
-	if err != nil {
-		return "", err
-	}
-	return string(bytes), nil
+	return newAttrs, nil
 }
 
 func formatNode(resourceAttrs map[string]string) string {

--- a/collector/components/servicenowexporter/servicenow_event.go
+++ b/collector/components/servicenowexporter/servicenow_event.go
@@ -1,9 +1,5 @@
 package servicenowexporter
 
-type ServiceNowEventRequestBody struct {
-	Records []ServiceNowEvent `json:"records"`
-}
-
 // https://docs.servicenow.com/bundle/vancouver-it-operations-management/page/product/event-management/task/send-events-via-web-service.html
 type ServiceNowEvent struct {
 	// The resource on the node impacted

--- a/collector/components/servicenowexporter/servicenow_event.go
+++ b/collector/components/servicenowexporter/servicenow_event.go
@@ -15,6 +15,6 @@ type ServiceNowEvent struct {
 	Description string `json:"description"`
 	Timestamp   string `json:"time_of_event"` // yyyy-MM-dd HH:mm:ss
 	// k8s.cluster.name:test-cluster,k8s.cluster.uid=12345
-	AdditionalInfo string `json:"additional_info,omitempty"` // actually a json string
-	Source         string `json:"source"`
+	AdditionalInfo map[string]string `json:"additional_info,omitempty"` // actually a json string
+	Source         string            `json:"source"`
 }


### PR DESCRIPTION
**Description:** Sends JSON in `additional_info` instead of a JSON string and normalizes map fields to string key/value pairs.

Example event from `k8sobjectsreceiver`:
```
      {
         "resource":";k8s.resource.name=events;event.domain=k8s;event.name=k8s-informer-hlasalesdemo1.17d8b16917e4bc96;watch-type=MODIFIED;deprecatedLastTimestamp=2024-06-13T22:39:31Z;kind=Event;apiVersion=events.k8s.io/v1;reason=ScalingReplicaSet;note=(combined from similar events): Scaled down replica set k8s-informer-hlasalesdemo1-f6d787558 to 0 from 1;type=Normal;deprecatedFirstTimestamp=2024-06-13T22:38:42Z;creationTimestamp=2024-06-13T22:38:42Z;name=k8s-informer-hlasalesdemo1.17d8b16917e4bc96;namespace=servicenow;uid=0d84ac74-444d-4a86-b011-8632feaed2c0;resourceVersion=28612",
         "node":"",
         "severity":"5",
         "type":"",
         "description":"{\"object\":{\"apiVersion\":\"events.k8s.io/v1\",\"deprecatedCount\":3,\"deprecatedFirstTimestamp\":\"2024-06-13T22:38:42Z\",\"deprecatedLastTimestamp\":\"2024-06-13T22:39:31Z\",\"deprecatedSource\":{\"component\":\"deployment-controller\"},\"eventTime\":null,\"kind\":\"Event\",\"metadata\":{\"creationTimestamp\":\"2024-06-13T22:38:42Z\",\"managedFields\":[{\"apiVersion\":\"v1\",\"fieldsType\":\"FieldsV1\",\"fieldsV1\":{\"f:count\":{},\"f:firstTimestamp\":{},\"f:involvedObject\":{},\"f:lastTimestamp\":{},\"f:message\":{},\"f:reason\":{},\"f:source\":{\"f:component\":{}},\"f:type\":{}},\"manager\":\"kube-controller-manager\",\"operation\":\"Update\",\"time\":\"2024-06-13T22:39:31Z\"}],\"name\":\"k8s-informer-hlasalesdemo1.17d8b16917e4bc96\",\"namespace\":\"servicenow\",\"resourceVersion\":\"28612\",\"uid\":\"0d84ac74-444d-4a86-b011-8632feaed2c0\"},\"note\":\"(combined from similar events): Scaled down replica set k8s-informer-hlasalesdemo1-f6d787558 to 0 from 1\",\"reason\":\"ScalingReplicaSet\",\"regarding\":{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"name\":\"k8s-informer-hlasalesdemo1\",\"namespace\":\"servicenow\",\"resourceVersion\":\"30426857\",\"uid\":\"77e5c426-44fd-4462-b028-c02d9beb1353\"},\"type\":\"Normal\"},\"type\":\"MODIFIED\"}",
         "time_of_event":"1970-01-01 00:00:00",
         "additional_info":{
            "apiVersion":"events.k8s.io/v1",
            "creationTimestamp":"2024-06-13T22:38:42Z",
            "deprecatedFirstTimestamp":"2024-06-13T22:38:42Z",
            "deprecatedLastTimestamp":"2024-06-13T22:39:31Z",
            "deprecatedSource_component":"deployment-controller",
            "event_domain":"k8s",
            "event_name":"k8s-informer-hlasalesdemo1.17d8b16917e4bc96",
            "k8s_resource_name":"events",
            "kind":"Event",
            "metadata_creationTimestamp":"2024-06-13T22:38:42Z",
            "metadata_name":"k8s-informer-hlasalesdemo1.17d8b16917e4bc96",
            "metadata_namespace":"servicenow",
            "metadata_resourceVersion":"28612",
            "metadata_uid":"0d84ac74-444d-4a86-b011-8632feaed2c0",
            "name":"k8s-informer-hlasalesdemo1.17d8b16917e4bc96",
            "namespace":"servicenow",
            "note":"(combined from similar events): Scaled down replica set k8s-informer-hlasalesdemo1-f6d787558 to 0 from 1",
            "reason":"ScalingReplicaSet",
            "regarding_apiVersion":"apps/v1",
            "regarding_kind":"Deployment",
            "regarding_name":"k8s-informer-hlasalesdemo1",
            "regarding_namespace":"servicenow",
            "regarding_resourceVersion":"30426857",
            "regarding_uid":"77e5c426-44fd-4462-b028-c02d9beb1353",
            "resourceVersion":"28612",
            "type":"Normal",
            "uid":"0d84ac74-444d-4a86-b011-8632feaed2c0",
            "watch-type":"MODIFIED"
         },
         "source":"sn-otel-collector"
      }
```
